### PR TITLE
[backend] feat: diary get List API 추가

### DIFF
--- a/backend/src/main/kotlin/knu/capstoneDesign/application/DiaryService.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/application/DiaryService.kt
@@ -1,6 +1,7 @@
 package knu.capstoneDesign.application
 
 import knu.capstoneDesign.data.dto.diary.req.DiaryPostReq
+import knu.capstoneDesign.data.dto.diary.res.DiaryGetListRes
 import knu.capstoneDesign.data.dto.diary.res.DiaryGetRes
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -11,4 +12,5 @@ interface DiaryService {
     fun get(userId: Int, date: LocalDate):ResponseEntity<DiaryGetRes>
     fun patch(diaryPostReq: DiaryPostReq): ResponseEntity<HttpStatusCode>
     fun delete(userId: Int, date: LocalDate): ResponseEntity<HttpStatusCode>
+    fun getList(userId: Int, startDate: LocalDate, endDate: LocalDate): ResponseEntity<List<DiaryGetListRes>>
 }

--- a/backend/src/main/kotlin/knu/capstoneDesign/application/impl/DiaryServiceImpl.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/application/impl/DiaryServiceImpl.kt
@@ -6,6 +6,7 @@ import knu.capstoneDesign.data.entity.User
 import knu.capstoneDesign.repository.DiaryRepository
 import knu.capstoneDesign.repository.UserRepository
 import knu.capstoneDesign.application.DiaryService
+import knu.capstoneDesign.data.dto.diary.res.DiaryGetListRes
 import knu.capstoneDesign.data.dto.diary.res.DiaryGetRes
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -62,6 +63,17 @@ class DiaryServiceImpl(
         println(diaryRepository.deleteByUserAndDate(user, date))
 
         return ResponseEntity.ok().build()
+    }
+
+    override fun getList(
+        userId: Int,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): ResponseEntity<List<DiaryGetListRes>> {
+
+        return ResponseEntity
+            .ok()
+            .body(diaryRepository.findByUserIdAndDateBetween(userId, startDate, endDate))
     }
 
     private fun getEmptyUserById(id: Int): User{

--- a/backend/src/main/kotlin/knu/capstoneDesign/data/dto/diary/res/DiaryGetListRes.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/data/dto/diary/res/DiaryGetListRes.kt
@@ -1,0 +1,7 @@
+package knu.capstoneDesign.data.dto.diary.res
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class DiaryGetListRes @QueryProjection constructor(
+    val content: String
+)

--- a/backend/src/main/kotlin/knu/capstoneDesign/presentation/DiaryController.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/presentation/DiaryController.kt
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import knu.capstoneDesign.data.dto.diary.req.DiaryPostReq
 import knu.capstoneDesign.application.DiaryService
+import knu.capstoneDesign.data.dto.diary.res.DiaryGetListRes
 import knu.capstoneDesign.data.dto.diary.res.DiaryGetRes
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
@@ -59,5 +60,14 @@ class DiaryController(private val diaryService: DiaryService) {
     )
     fun delete(@RequestParam userId:Int, @RequestParam date:LocalDate): ResponseEntity<HttpStatusCode>{
         return diaryService.delete(userId, date)
+    }
+
+    @GetMapping("/list")
+    @Operation(summary = "일기 리스트 조회 API")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "성공", content = arrayOf(Content()))
+    )
+    fun getList(@RequestParam userId: Int, @RequestParam startDate: LocalDate, @RequestParam endDate: LocalDate): ResponseEntity<List<DiaryGetListRes>>{
+        return diaryService.getList(userId, startDate, endDate)
     }
 }

--- a/backend/src/main/kotlin/knu/capstoneDesign/repository/custom/DiaryRepositoryCustom.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/repository/custom/DiaryRepositoryCustom.kt
@@ -1,4 +1,9 @@
 package knu.capstoneDesign.repository.custom
 
+import knu.capstoneDesign.data.dto.diary.res.DiaryGetListRes
+import java.time.LocalDate
+
 interface DiaryRepositoryCustom {
+
+    fun findByUserIdAndDateBetween(userId: Int, startDate: LocalDate, endDate: LocalDate): List<DiaryGetListRes>
 }

--- a/backend/src/main/kotlin/knu/capstoneDesign/repository/queryDsl/DiaryQueryDsl.kt
+++ b/backend/src/main/kotlin/knu/capstoneDesign/repository/queryDsl/DiaryQueryDsl.kt
@@ -1,9 +1,27 @@
 package knu.capstoneDesign.repository.queryDsl
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import knu.capstoneDesign.data.dto.diary.res.DiaryGetListRes
+import knu.capstoneDesign.data.dto.diary.res.QDiaryGetListRes
+import knu.capstoneDesign.data.entity.QDiary.diary
 import knu.capstoneDesign.repository.custom.DiaryRepositoryCustom
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class DiaryQueryDsl(private val jpaQueryFactory: JPAQueryFactory): DiaryRepositoryCustom {
+
+    override fun findByUserIdAndDateBetween(
+        userId: Int,
+        startDate: LocalDate,
+        endDate: LocalDate
+    ): List<DiaryGetListRes> {
+        return jpaQueryFactory.select(QDiaryGetListRes(diary.content))
+            .from(diary)
+            .where(
+                diary.user.id.eq(userId),
+                diary.date.between(startDate, endDate)
+            )
+            .fetch()
+    }
 }

--- a/backend/src/test/kotlin/knu/capstoneDesign/DiaryTest.kt
+++ b/backend/src/test/kotlin/knu/capstoneDesign/DiaryTest.kt
@@ -178,4 +178,40 @@ class DiaryTest(
         val currentCount = diaryRepository.count()
         assert(originalCount == currentCount)
     }
+
+    /**
+     * @author Seungkyu-Han
+     * diary Get List Api Test
+     */
+    @Test
+    fun testGetList(){
+        //given
+        val count = 10
+        val contentList = mutableListOf<String>()
+
+        for (i in 1..count)
+            contentList.add("GET LIST 테스트$i 일기입니다.")
+
+        val diaryList = mutableListOf<Diary>()
+
+        for (i in 1..count)
+            diaryList.add(Diary(testUser, LocalDate.of(1000, 1, i), contentList[i - 1]))
+
+        diaryRepository.saveAll(diaryList)
+
+        //then
+        val result = diaryService.getList(testUser.id,
+            LocalDate.of(1000, 1, 1),
+            LocalDate.of(1000, 12, 30)).body
+
+        //when
+        assert(result?.size == count)
+        for(i in 1..count){
+            assert(result?.get(i - 1)?.content == contentList[i - 1])
+        }
+
+
+        //after
+        diaryRepository.deleteAll(diaryList)
+    }
 }


### PR DESCRIPTION
- 일기를 리스트로 조회 가능한 API 추가
- 테스트 완료
<img width="285" alt="image" src="https://github.com/Seungkyu-Han/CapstoneDesign2/assets/98071131/1c7b62b4-5e68-4123-9e2f-7731112bc43f">

